### PR TITLE
Adjust filesystem persmissions

### DIFF
--- a/nz.mega.MEGAsync.yml
+++ b/nz.mega.MEGAsync.yml
@@ -3,7 +3,7 @@ sdk: org.kde.Sdk
 runtime: org.kde.Platform
 runtime-version: '5.15'
 finish-args:
-  - --filesystem=~/MEGA:create
+  - --filesystem=~/MEGAsync:create
   - --filesystem=~/MEGAsync Downloads:create
   - --own-name=org.kde.StatusNotifierItem-2-1
   - --share=ipc


### PR DESCRIPTION
The original permissions allow the creation of the folder `~/MEGA` but a fresh install tries to use `~/MEGAsync` when using selective sync.

I am not sure if the original permission is needed at all so I dropped it.

![selective_sync](https://user-images.githubusercontent.com/27500920/111512210-cb6cbf80-874f-11eb-9526-9730a0e98dd4.png)
