### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/nz.mega.MEGAsync.yml
+++ b/nz.mega.MEGAsync.yml
@@ -7,7 +7,6 @@ finish-args:
   - --filesystem=~/MEGA:create
   - --filesystem=~/MEGAsync Downloads:create
   - --filesystem=~/MEGAsync:create
-  - --own-name=org.kde.*
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025